### PR TITLE
Use CRON to manage staging

### DIFF
--- a/.github/workflows/reset.yaml
+++ b/.github/workflows/reset.yaml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
   schedule:
     # 12-15 through 01-14:
-    - cron: '0 * 15-31 12 *' # minute 0 every hour in December day 15 and after
-    - cron: '0 * 1-14 1 *'  # minute 0 every hour in January day 14 and before
+    - cron: '0 0 15-31 12 *' # at 0.00 every day in December day 15 and after
+    - cron: '0 0 1-14 1 *'  # at 0.00 every day in January day 14 and before
     # 03-15 through 04-14:
-    - cron: '0 * 15-31 3 *' # minute 0 every hour in March day 15 and after
-    - cron: '0 * 1-14 4 *'  # minute 0 every hour in April day 14 and before
+    - cron: '0 0 15-31 3 *' # at 0.00 every day in March day 15 and after
+    - cron: '0 0 1-14 4 *'  # at 0.00 every day in April day 14 and before
     # 06-15 through 07-14:
-    - cron: '0 * 15-31 6 *' # minute 0 every hour in June day 15 and after
-    - cron: '0 * 1-14 7 *'  # minute 0 every hour in July day 14 and before
+    - cron: '0 0 15-31 6 *' # at 0.00 every day in June day 15 and after
+    - cron: '0 0 1-14 7 *'  # at 0.00 every day in July day 14 and before
     # 09-15 through 10-14:
-    - cron: '0 * 15-31 9 *' # minute 0 every hour in September day 15 and after
-    - cron: '0 * 1-14 10 *'  # minute 0 every hour in October day 14 and before
+    - cron: '0 0 15-31 9 *' # at 0.00 every day in September day 15 and after
+    - cron: '0 0 1-14 10 *' # at 0.00 every day in October day 14 and before
 
 jobs:
   reset_staging:

--- a/.github/workflows/reset.yaml
+++ b/.github/workflows/reset.yaml
@@ -1,0 +1,43 @@
+name: reset
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 12-15 through 01-14:
+    - cron: '0 * 15-31 12 *' # minute 0 every hour in December day 15 and after
+    - cron: '0 * 1-14 1 *'  # minute 0 every hour in January day 14 and before
+    # 03-15 through 04-14:
+    - cron: '0 * 15-31 3 *' # minute 0 every hour in March day 15 and after
+    - cron: '0 * 1-14 4 *'  # minute 0 every hour in April day 14 and before
+    # 06-15 through 07-14:
+    - cron: '0 * 15-31 6 *' # minute 0 every hour in June day 15 and after
+    - cron: '0 * 1-14 7 *'  # minute 0 every hour in July day 14 and before
+    # 09-15 through 10-14:
+    - cron: '0 * 15-31 9 *' # minute 0 every hour in September day 15 and after
+    - cron: '0 * 1-14 10 *'  # minute 0 every hour in October day 14 and before
+
+jobs:
+  reset_staging:
+    runs-on: macOS-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Check out the staging universe.
+        uses: actions/checkout@v4
+
+      - name: Reset staging.
+        run: rm packages.json
+
+      - name: Commit and push changes.
+        run: |
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git config --global user.name github-actions
+            git config --global user.email actions@github.com
+            git commit -am "Reset staging"
+            git push -u origin main
+          fi

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,59 +1,24 @@
-name: staging
+name: update
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *'
+    # 01-15 through 02-14:
+    - cron: '0 * 15-31 1 *' # minute 0 every hour in January day 15 and after
+    - cron: '0 * 1-14 2 *'  # minute 0 every hour in February day 14 and before
+    # 04-15 through 05-14:
+    - cron: '0 * 15-31 4 *' # minute 0 every hour in April day 15 and after
+    - cron: '0 * 1-14 5 *'  # minute 0 every hour in May day 14 and before
+    # 07-15 through 08-14:
+    - cron: '0 * 15-31 7 *' # minute 0 every hour in July day 15 and after
+    - cron: '0 * 1-14 8 *'  # minute 0 every hour in August day 14 and before
+    # 10-15 through 11-14:
+    - cron: '0 * 15-31 10 *' # minute 0 every hour in October day 15 and after
+    - cron: '0 * 1-14 11 *'  # minute 0 every hour in November day 14 and before
 
 jobs:
-  staging_is_active:
-    runs-on: macOS-latest
-    outputs:
-      staging_is_active: ${{ steps.staging_is_active.outputs.staging_is_active }}
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_KEEP_PKG_SOURCE: yes
-
-    steps:
-      - name: Install R.
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install helper R package.
-        shell: Rscript {0}
-        run: |
-          install.packages(
-            pkgs = "multiverse.internals",
-            repos = c("https://cloud.r-project.org", "https://community.r-multiverse.org"),
-            type = "binary"
-          )
-        
-
-      - name: Check if Staging is active.
-        id: staging_is_active
-        shell: Rscript {0}
-        run: |
-          is_active <- multiverse.internals::staging_is_active(
-            start = c("01-15", "04-15", "07-15", "10-15"),
-            today = Sys.Date()
-          )
-          if (is_active) {
-            print("Staging is active. Next step is to update the Staging universe.")
-          } else {
-            print("Staging is not active. Leaving the Staging universe alone.")
-          }
-          cat(
-            paste0("staging_is_active=", tolower(as.character(is_active))),
-            file = Sys.getenv("GITHUB_OUTPUT"),
-            append = TRUE
-          )
-
   update_staging:
     runs-on: macOS-latest
-    needs: staging_is_active
-    if: needs.staging_is_active.outputs.staging_is_active == 'true'
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -131,6 +96,6 @@ jobs:
           else
             git config --global user.name github-actions
             git config --global user.email actions@github.com
-            git commit -m "Update issues"
+            git commit -m "Update staging"
             git push -u origin main
           fi


### PR DESCRIPTION
@shikokuchuo, this PR uses CRON expressions to schedule when staging updates and when it resets. I think this is a lot simpler, easier to maintain, and more transparent than the awkward `multiverse.internals::staging_is_active()`.